### PR TITLE
Leverage __builtin_bswap{16,32,64} When Available

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -1,5 +1,5 @@
 #
-#    Copyright 2015-2016 Nest Labs Inc. All Rights Reserved.
+#    Copyright 2015-2017 Nest Labs Inc. All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -31,10 +31,11 @@ include_HEADERS =             \
     nlio-base.hpp             \
     nlio-byteorder-big.h      \
     nlio-byteorder-big.hpp    \
-    nlio-byteorder.h          \
-    nlio-byteorder.hpp        \
     nlio-byteorder-little.h   \
     nlio-byteorder-little.hpp \
+    nlio-byteorder.h          \
+    nlio-byteorder.hpp        \
+    nlio-private.h            \
     nlio.h                    \
     nlio.hpp                  \
     $(NULL)

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -15,7 +15,7 @@
 @SET_MAKE@
 
 #
-#    Copyright 2015-2016 Nest Labs Inc. All Rights Reserved.
+#    Copyright 2015-2017 Nest Labs Inc. All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -351,10 +351,11 @@ include_HEADERS = \
     nlio-base.hpp             \
     nlio-byteorder-big.h      \
     nlio-byteorder-big.hpp    \
-    nlio-byteorder.h          \
-    nlio-byteorder.hpp        \
     nlio-byteorder-little.h   \
     nlio-byteorder-little.hpp \
+    nlio-byteorder.h          \
+    nlio-byteorder.hpp        \
+    nlio-private.h            \
     nlio.h                    \
     nlio.hpp                  \
     $(NULL)

--- a/include/nlbyteorder.h
+++ b/include/nlbyteorder.h
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2012-2016 Nest Labs Inc. All Rights Reserved.
+ *    Copyright 2012-2017 Nest Labs Inc. All Rights Reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,7 +25,39 @@
 #ifndef NLBYTEORDER_H
 #define NLBYTEORDER_H
 
+#include <nlio-private.h>
+
 #include <stdint.h>
+
+/*
+ * If we are compiling under clang, GCC, or any such compatible
+ * compiler, in which -fno-builtins or -ffreestanding might be
+ * asserted, thereby eliminating built-in function optimization, we
+ * STILL want to leverage built-in bswap{16,32,64}, if available. We
+ * want this because it allows the compiler to use
+ * architecture-specific machine instructions or inline code
+ * generation to optimize an otherwise-generic and non-optimized code
+ * for byte reordering, which is the exactly the kind of efficiency
+ * that would be expected of nlByteOrder.
+ */
+
+#if __nlIOHasBuiltin(__builtin_bswap16)
+#define __nlBYTEORDER_BSWAP16 __builtin_bswap16
+#else
+#define __nlBYTEORDER_BSWAP16 nlByteOrderConstantSwap16
+#endif
+
+#if __nlIOHasBuiltin(__builtin_bswap32)
+#define __nlBYTEORDER_BSWAP32 __builtin_bswap32
+#else
+#define __nlBYTEORDER_BSWAP32 nlByteOrderContantSwap32
+#endif
+
+#if __nlIOHasBuiltin(__builtin_bswap64)
+#define __nlBYTEORDER_BSWAP64 __builtin_bswap64
+#else
+#define __nlBYTEORDER_BSWAP64 nlByteOrderConstantSwap64
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -191,7 +223,7 @@ static inline nlByteOrder nlByteOrderGetCurrent(void)
  */
 static inline uint16_t nlByteOrderValueSwap16(uint16_t inValue)
 {
-    return nlByteOrderConstantSwap16(inValue);
+    return __nlBYTEORDER_BSWAP16(inValue);
 }
 
 /**
@@ -204,7 +236,7 @@ static inline uint16_t nlByteOrderValueSwap16(uint16_t inValue)
  */
 static inline uint32_t nlByteOrderValueSwap32(uint32_t inValue)
 {
-    return nlByteOrderConstantSwap32(inValue);
+    return __nlBYTEORDER_BSWAP32(inValue);
 }
 
 /**
@@ -217,7 +249,7 @@ static inline uint32_t nlByteOrderValueSwap32(uint32_t inValue)
  */
 static inline uint64_t nlByteOrderValueSwap64(uint64_t inValue)
 {
-    return nlByteOrderConstantSwap64(inValue);
+    return __nlBYTEORDER_BSWAP64(inValue);
 }
 
 /**
@@ -281,8 +313,10 @@ static inline void nlByteOrderPointerSwap64(uint64_t *inValue)
 }
 #endif
 
+#undef __nlBYTEORDER_BSWAP16
+#undef __nlBYTEORDER_BSWAP32
+#undef __nlBYTEORDER_BSWAP64
+
 #endif /* NLBYTEORDER_H */
-
-
 
 

--- a/include/nlio-base.h
+++ b/include/nlio-base.h
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2013-2016 Nest Labs Inc. All Rights Reserved.
+ *    Copyright 2013-2017 Nest Labs Inc. All Rights Reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -24,27 +24,23 @@
 #ifndef NLIO_BASE_H
 #define NLIO_BASE_H
 
+#include <nlio-private.h>
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
 
 /*
- * If we are compiling under clang, GCC, or any such compatible compiler, in which
- * -fno-builtins or -ffreestanding might be asserted, thereby eliminating built-in
- * function optimization, we STILL want built-in memcpy. We want this because it allows
- * the compiler to use architecture-specific machine instructions or inline code
- * generation to optimize an otherwise-expensive memcpy for unaligned reads and writes,
- * which is the exactly the kind of efficiency that would be expected of nlIO.
+ * If we are compiling under clang, GCC, or any such compatible
+ * compiler, in which -fno-builtins or -ffreestanding might be
+ * asserted, thereby eliminating built-in function optimization, we
+ * STILL want built-in memcpy. We want this because it allows the
+ * compiler to use architecture-specific machine instructions or
+ * inline code generation to optimize an otherwise-expensive memcpy
+ * for unaligned reads and writes, which is the exactly the kind of
+ * efficiency that would be expected of nlIO.
  */
-#ifdef __clang__
-#define nlIOHasBuiltin(...) __has_builtin(__VA_ARGS__)
-#elif defined __GNUC__
-#define nlIOHasBuiltin(...) 1
-#else
-#define nlIOHasBuiltin(...) 0
-#endif /* __clang__ */
-
-#if nlIOHasBuiltin(__builtin_memcpy)
+#if __nlIOHasBuiltin(__builtin_memcpy)
 #define __nlIO_MEMCPY __builtin_memcpy
 #else
 #define __nlIO_MEMCPY memcpy

--- a/include/nlio-private.h
+++ b/include/nlio-private.h
@@ -1,0 +1,50 @@
+/**
+ *    Copyright 2017 Nest Labs Inc. All Rights Reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines private macros and interfaces.
+ */
+
+#ifndef NLIO_PRIVATE_H
+#define NLIO_PRIVATE_H
+
+/*
+ * If we are compiling under clang, GCC, or any such compatible
+ * compiler, in which -fno-builtins or -ffreestanding might be
+ * asserted, thereby eliminating built-in function optimization, we
+ * may STILL want to leverage built-ins.
+ *
+ * Provide an internal convenience macro to do so.
+ */
+
+/**
+ *  @def __nlIOHasBuiltin
+ *
+ *  @brief
+ *     Determines whether or not the compiler in effect has support
+ *     for the specified built-in function.
+ *
+ */
+#ifdef __clang__
+#define __nlIOHasBuiltin(...) __has_builtin(__VA_ARGS__)
+#elif defined __GNUC__
+#define __nlIOHasBuiltin(...) 1
+#else
+#define __nlIOHasBuiltin(...) 0
+#endif /* __clang__ */
+
+#endif /* NLIO_PRIVATE_H */


### PR DESCRIPTION
Leverage __builtin_bswap{16,32,64} when available in preference to nlByteOrderConstantSwap{16,32,64} for nlByteOrderValueSwap{16,32,64}.