### PR TITLE
Use quotes over angle brackets for includes

### DIFF
--- a/include/nlbyteorder.h
+++ b/include/nlbyteorder.h
@@ -25,7 +25,7 @@
 #ifndef NLBYTEORDER_H
 #define NLBYTEORDER_H
 
-#include <nlio-private.h>
+#include "nlio-private.h"
 
 #include <stdint.h>
 

--- a/include/nlbyteorder.hpp
+++ b/include/nlbyteorder.hpp
@@ -25,7 +25,7 @@
 #ifndef NLBYTEORDER_HPP
 #define NLBYTEORDER_HPP
 
-#include <nlbyteorder.h>
+#include "nlbyteorder.h"
 
 namespace nl
 {

--- a/include/nlio-base.h
+++ b/include/nlio-base.h
@@ -24,7 +24,7 @@
 #ifndef NLIO_BASE_H
 #define NLIO_BASE_H
 
-#include <nlio-private.h>
+#include "nlio-private.h"
 
 #include <stdbool.h>
 #include <stdint.h>

--- a/include/nlio-base.hpp
+++ b/include/nlio-base.hpp
@@ -24,7 +24,7 @@
 #ifndef NLIO_BASE_HPP
 #define NLIO_BASE_HPP
 
-#include <nlio-base.h>
+#include "nlio-base.h"
 
 namespace nl
 {

--- a/include/nlio-byteorder-big.h
+++ b/include/nlio-byteorder-big.h
@@ -25,8 +25,8 @@
 #ifndef NLIO_BYTEORDER_BIG_H
 #define NLIO_BYTEORDER_BIG_H
 
-#include <nlio-base.h>
-#include <nlbyteorder.h>
+#include "nlio-base.h"
+#include "nlbyteorder.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/nlio-byteorder-big.hpp
+++ b/include/nlio-byteorder-big.hpp
@@ -25,8 +25,8 @@
 #ifndef NLIO_BYTEORDER_BIG_HPP
 #define NLIO_BYTEORDER_BIG_HPP
 
-#include <nlio-base.hpp>
-#include <nlbyteorder.hpp>
+#include "nlio-base.hpp"
+#include "nlbyteorder.hpp"
 
 namespace nl
 {

--- a/include/nlio-byteorder-little.h
+++ b/include/nlio-byteorder-little.h
@@ -25,8 +25,8 @@
 #ifndef NLIO_BYTEORDER_LITTLE_H
 #define NLIO_BYTEORDER_LITTLE_H
 
-#include <nlio-base.h>
-#include <nlbyteorder.h>
+#include "nlio-base.h"
+#include "nlbyteorder.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/nlio-byteorder-little.hpp
+++ b/include/nlio-byteorder-little.hpp
@@ -25,8 +25,8 @@
 #ifndef NLIO_BYTEORDER_LITTLE_HPP
 #define NLIO_BYTEORDER_LITTLE_HPP
 
-#include <nlio-base.hpp>
-#include <nlbyteorder.hpp>
+#include "nlio-base.hpp"
+#include "nlbyteorder.hpp"
 
 namespace nl
 {

--- a/include/nlio-byteorder.h
+++ b/include/nlio-byteorder.h
@@ -24,10 +24,10 @@
 #ifndef NLIO_BYTEORDER_H
 #define NLIO_BYTEORDER_H
 
-#include <nlio-base.h>
-#include <nlbyteorder.h>
+#include "nlio-base.h"
+#include "nlbyteorder.h"
 
-#include <nlio-byteorder-big.h>
-#include <nlio-byteorder-little.h>
+#include "nlio-byteorder-big.h"
+#include "nlio-byteorder-little.h"
 
 #endif /* NLIO_BYTEORDER_H */

--- a/include/nlio-byteorder.hpp
+++ b/include/nlio-byteorder.hpp
@@ -24,10 +24,10 @@
 #ifndef NLIO_BYTEORDER_HPP
 #define NLIO_BYTEORDER_HPP
 
-#include <nlio-base.hpp>
-#include <nlbyteorder.hpp>
+#include "nlio-base.hpp"
+#include "nlbyteorder.hpp"
 
-#include <nlio-byteorder-big.hpp>
-#include <nlio-byteorder-little.hpp>
+#include "nlio-byteorder-big.hpp"
+#include "nlio-byteorder-little.hpp"
 
 #endif // NLIO_BYTEORDER_HPP

--- a/include/nlio.h
+++ b/include/nlio.h
@@ -25,8 +25,8 @@
 #ifndef NLIO_H
 #define NLIO_H
 
-#include <nlio-base.h>
-#include <nlio-byteorder.h>
+#include "nlio-base.h"
+#include "nlio-byteorder.h"
 
 #endif /* NLIO_H */
 

--- a/include/nlio.hpp
+++ b/include/nlio.hpp
@@ -25,8 +25,8 @@
 #ifndef NLIO_HPP
 #define NLIO_HPP
 
-#include <nlio-base.hpp>
-#include <nlio-byteorder.hpp>
+#include "nlio-base.hpp"
+#include "nlio-byteorder.hpp"
 
 #endif // NLIO_HPP
 


### PR DESCRIPTION
Use double quotes in lieu of angle brackets for including headers in the
same directory. This avoids unintended inclusion of same-named headers
from system include directories.